### PR TITLE
Remove dangling event listener to avoid memory leaks

### DIFF
--- a/src/components/scroll.jsx
+++ b/src/components/scroll.jsx
@@ -4,13 +4,19 @@ import "./scroll.scss";
 const ScrollToTop = () => {
   const [showTopBtn, setShowTopBtn] = useState(false);
   useEffect(() => {
-    window.addEventListener("scroll", () => {
+    const scrollListener = () => {
       if (window.scrollY > 400) {
         setShowTopBtn(true);
       } else {
         setShowTopBtn(false);
       }
-    });
+    };
+
+    window.addEventListener("scroll", scrollListener);
+
+    return () => {
+      window.removeEventListener("scroll", scrollListener);
+    };
   }, []);
   const goToTop = () => {
     window.scrollTo({


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications. 
While running the tool and analyzing the code of TBT, we saw that it does a very good job of ensuring that all async operations are cancelled when the component unmounts. However, as per Memlab execution results, we found that the removal of the event listener is forgotten in one place and is causing the memory to leak (screenshots below).

[before]
<img width="715" alt="Screen Shot 2023-01-24 at 2 15 28 AM" src="https://user-images.githubusercontent.com/56495631/214107541-34b12fc3-f8d8-4319-97f4-49b87aae61a2.png">
<img width="800" alt="Screen Shot 2023-01-24 at 2 15 54 AM" src="https://user-images.githubusercontent.com/56495631/214107484-053943d0-dff3-4d5c-87cf-a7c705b829b4.png">
Hence we added the fix by removing the event listeners and you can see the heap size and # of leaks reducing noticeably:
 <br />
<img width="785" alt="Screen Shot 2023-01-24 at 2 21 33 AM" src="https://user-images.githubusercontent.com/56495631/214108567-aa41d34a-0893-44db-b43e-c2e37a997160.png">
<img width="883" alt="Screen Shot 2023-01-24 at 2 20 46 AM" src="https://user-images.githubusercontent.com/56495631/214108585-c9477ecf-3d69-462a-8187-9e2b7ac486ed.png">



You can test this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in txt form):
[test-scenario-tbt.txt](https://github.com/tbtMEC/tbt-website/files/10482199/test-scenario-tbt.txt)

Note that some other reported leaks originate from React's internal objects, hence ignored.
