### PR TITLE
Added margin-top to err div element

### DIFF
--- a/src/styles/fourNotFour.css
+++ b/src/styles/fourNotFour.css
@@ -3,6 +3,7 @@
   background-attachment: fixed;
   background-size: contain;
   background-image: url("https://the-book-thieves.netlify.app/assets/Stars.png");
+  margin-top: 2.5rem;
   #err h1 {
     font-family: Impact, Haettenschweiler, "Arial Narrow Bold", sans-serif;
     font-weight: bold;


### PR DESCRIPTION
When the screen's width is between 1000px-1021px, the navbar list elements and err block overlap.